### PR TITLE
Protentional fix where it blocked all files

### DIFF
--- a/FSRM_NOCRYPTO_2012_to_2022.ps1
+++ b/FSRM_NOCRYPTO_2012_to_2022.ps1
@@ -134,18 +134,11 @@ $Commande = New-FsrmAction -Type Command -Command "c:\Windows\System32\cmd.exe" 
    
 # Fonction to convert the extensions list #
 # in a compatible FSRM format             #                       
-
-function ConvertFrom-Json20([Object] $obj)
-{
-    Add-Type -AssemblyName System.Web.Extensions
-    $serializer = New-Object System.Web.Script.Serialization.JavaScriptSerializer
-    return ,$serializer.DeserializeObject($obj)
-}
+# Removed the Convert to JSON 20 Func to solve the issue blocking all files
 
 Try
 {
-$jsonStr = Invoke-WebRequest -Uri $url -UseBasicParsing
-$monitoredExtensions = @(ConvertFrom-Json20($jsonStr) | % { $_.filters })
+$monitoredExtensions = ((Invoke-WebRequest -Uri $url -ErrorAction Stop).Content | ConvertFrom-Json).filters
 }
 Catch
 {


### PR DESCRIPTION
After adding this fix to the script, I was able to run it successfully with my list of extensions, and it appeared that it no longer blocks all files. However, it should be tested to ensure that nothing else breaks.